### PR TITLE
Add \/ matchers

### DIFF
--- a/src/main/scala/DisjunctionMatchers.scala
+++ b/src/main/scala/DisjunctionMatchers.scala
@@ -1,0 +1,121 @@
+package org.specs2.scalaz
+
+import scalaz.{ -\/, \/, \/- }
+
+import org.specs2.matcher._
+import org.specs2.text.Quote._
+import org.specs2.execute.{ Failure, Result }
+
+trait DisjunctionMatchers { outer =>
+
+  def beRightDisjunction[T](t: => T) =
+    new Matcher[\/[_, T]] {
+      def apply[S <: \/[_, T]](value: Expectable[S]) = {
+        val expected = t
+        result(
+          value.value == \/.right(t),
+          value.description + " is \\/- with value" + q(expected),
+          value.description + " is not \\/- with value" + q(expected),
+          value
+        )
+      }
+    }
+
+  def beRightDisjunction[T] = new RightDisjunctionMatcher[T]
+
+  class RightDisjunctionMatcher[T] extends Matcher[\/[_, T]] {
+    def apply[S <: \/[_, T]](value: Expectable[S]) = {
+      result(
+        value.value.isRight,
+        value.description + " is \\/-",
+        value.description + " is not \\/-",
+        value
+      )
+    }
+
+    def like(f: PartialFunction[T, MatchResult[_]]) = this and partialMatcher(f)
+
+    private def partialMatcher(f: PartialFunction[T, MatchResult[_]]) = new Matcher[\/[_, T]] {
+      def apply[S <: \/[_, T]](value: Expectable[S]) = {
+        val res: Result = value.value match {
+          case \/-(t) if f.isDefinedAt(t)  => f(t).toResult
+          case \/-(t) if !f.isDefinedAt(t) => Failure("function undefined")
+          case other                            => Failure("no match")
+        }
+        result(
+          res.isSuccess,
+          value.description + " is \\/-[T] and " + res.message,
+          value.description + " is \\/-[T] but " + res.message,
+          value
+        )
+      }
+    }
+  }
+
+  def rightDisjunction[T](t: => T) = beRightDisjunction(t)
+  def rightDisjunction[T] = beRightDisjunction
+
+  def beLeftDisjunction[T](t: => T) = new Matcher[\/[T, _]] {
+    def apply[S <: \/[T, _]](value: Expectable[S]) = {
+      val expected = t
+      result(
+        value.value == \/.left(t),
+        value.description + " is -\\/ with value" + q(expected),
+        value.description + " is not -\\/ with value" + q(expected),
+        value
+      )
+    }
+  }
+
+  def beLeftDisjunction[T] = new LeftDisjunctionMatcher[T]
+  class LeftDisjunctionMatcher[T] extends Matcher[\/[T, _]] {
+    def apply[S <: \/[T, _]](value: Expectable[S]) = {
+      result(
+        value.value.isLeft,
+        value.description + " is -\\/",
+        value.description + " is not -\\/",
+        value
+      )
+    }
+
+    def like(f: PartialFunction[T, MatchResult[_]]) = this and partialMatcher(f)
+
+    private def partialMatcher(f: PartialFunction[T, MatchResult[_]]) = new Matcher[\/[T, _]] {
+      def apply[S <: \/[T, _]](value: Expectable[S]) = {
+        val res: Result = value.value match {
+          case -\/(t) if f.isDefinedAt(t)  => f(t).toResult
+          case -\/(t) if !f.isDefinedAt(t) => Failure("function undefined")
+          case other                            => Failure("no match")
+        }
+        result(
+          res.isSuccess,
+          value.description + " is -\\/[T] and " + res.message,
+          value.description + " is -\\/[T] but " + res.message,
+          value
+        )
+      }
+    }
+  }
+
+  def leftDisjunction[T](t: => T) = beLeftDisjunction(t)
+  def leftDisjunction[T] = beLeftDisjunction
+
+  implicit def toDisjunctionResultMatcher[F, S](result: MatchResult[\/[F, S]]) =
+    new DisjunctionResultMatcher(result)
+
+  class DisjunctionResultMatcher[F, S](result: MatchResult[\/[F, S]]) {
+    def leftDisjunction(f: => F) = result(outer beLeftDisjunction f)
+    def beLeftDisjunction(f: => F) = result(outer beLeftDisjunction f)
+    def rightDisjunction(s: => S) = result(outer beRightDisjunction s)
+    def beRightDisjunction(s: => S) = result(outer beRightDisjunction s)
+
+    def leftDisjunction = result(outer.beLeftDisjunction)
+    def beLeftDisjunction = result(outer.beLeftDisjunction)
+    def rightDisjunction = result(outer.beRightDisjunction)
+    def beRightDisjunction = result(outer.beRightDisjunction)
+  }
+}
+
+object DisjunctionMatchers extends DisjunctionMatchers
+
+// vim: expandtab:ts=2:sw=2

--- a/src/main/scala/ScalazMatchers.scala
+++ b/src/main/scala/ScalazMatchers.scala
@@ -4,7 +4,7 @@ import scalaz._
 
 import org.specs2.matcher._
 
-trait ScalazMatchers extends ValidationMatchers { outer =>
+trait ScalazMatchers extends ValidationMatchers with DisjunctionMatchers { outer =>
 
   /** Equality matcher with a [[scalaz.Equal]] typeclass */
   def equal[T : Equal : Show](expected: T): Matcher[T] = new Matcher[T] {

--- a/src/test/scala/DisjunctionMatchersSpec.scala
+++ b/src/test/scala/DisjunctionMatchersSpec.scala
@@ -1,0 +1,35 @@
+package org.specs2.scalaz
+
+import scalaz.\/
+
+import org.specs2.Specification
+
+class DisjunctionMatchersSpec extends Specification with DisjunctionMatchers {
+  def is =
+    "beRightDisjunction matches \\/-" ! rightMatches ^
+    "beLeftDisjunction matches -\\/"    ! leftMatches
+
+  def rightMatches =
+    (\/.right(3) must     beRightDisjunction.like{
+      case a => a must_== 3
+    })                                            and
+    (\/.right(3) must     beRightDisjunction)     and
+    (\/.right(3) must     beRightDisjunction(3))  and
+    (\/.left(3)  must not beRightDisjunction)     and
+    (\/.right(3) must     be rightDisjunction)    and
+    (\/.right(3) must     be rightDisjunction(3)) and
+    (\/.left(3)  must not be rightDisjunction)
+
+  def leftMatches =
+    (\/.left(3)  must     beLeftDisjunction.like{
+      case a => a must_== 3
+    }) and
+    (\/.right(3) must not beLeftDisjunction)     and
+    (\/.left(3)  must     beLeftDisjunction)     and
+    (\/.left(3)  must     beLeftDisjunction(3))  and
+    (\/.right(3) must not be leftDisjunction)    and
+    (\/.left(3)  must     be leftDisjunction)    and
+    (\/.left(3)  must     be leftDisjunction(3))
+}
+
+// vim: expandtab:ts=2:sw=2


### PR DESCRIPTION
The verbose names beDisjunctionRight and beDisjunctionLeft were chosen
to avoid name conflicts with specs2's beRight and beLeft, which are for
scala.util.Either.

As is quite evident, this was basically a copy/paste of the validation matchers with some find/replace to go from Validation to \/.
