### PR TITLE
Add aliases be_\/- and be_-\/ to left/right disjunction matchers

### DIFF
--- a/src/main/scala/DisjunctionMatchers.scala
+++ b/src/main/scala/DisjunctionMatchers.scala
@@ -53,7 +53,9 @@ trait DisjunctionMatchers { outer =>
   }
 
   def rightDisjunction[T](t: => T) = beRightDisjunction(t)
+  def be_\/-[T](t: => T) = beRightDisjunction(t)
   def rightDisjunction[T] = beRightDisjunction
+  def be_\/-[T]: Matcher[\/[_, T]] = beRightDisjunction
 
   def beLeftDisjunction[T](t: => T) = new Matcher[\/[T, _]] {
     def apply[S <: \/[T, _]](value: Expectable[S]) = {
@@ -98,7 +100,9 @@ trait DisjunctionMatchers { outer =>
   }
 
   def leftDisjunction[T](t: => T) = beLeftDisjunction(t)
+  def be_-\/[T](t: => T) = beLeftDisjunction(t)
   def leftDisjunction[T] = beLeftDisjunction
+  def be_-\/[T]: Matcher[\/[T, _]] = beLeftDisjunction
 
   implicit def toDisjunctionResultMatcher[F, S](result: MatchResult[\/[F, S]]) =
     new DisjunctionResultMatcher(result)
@@ -106,13 +110,17 @@ trait DisjunctionMatchers { outer =>
   class DisjunctionResultMatcher[F, S](result: MatchResult[\/[F, S]]) {
     def leftDisjunction(f: => F) = result(outer beLeftDisjunction f)
     def beLeftDisjunction(f: => F) = result(outer beLeftDisjunction f)
+    def be_-\/(f: => F) = result(outer beLeftDisjunction f)
     def rightDisjunction(s: => S) = result(outer beRightDisjunction s)
     def beRightDisjunction(s: => S) = result(outer beRightDisjunction s)
+    def be_\/-(s: => S) = result(outer beRightDisjunction s)
 
     def leftDisjunction = result(outer.beLeftDisjunction)
     def beLeftDisjunction = result(outer.beLeftDisjunction)
+    def be_-\/ = result(outer.beLeftDisjunction)
     def rightDisjunction = result(outer.beRightDisjunction)
     def beRightDisjunction = result(outer.beRightDisjunction)
+    def be_\/- = result(outer.beRightDisjunction)
   }
 }
 

--- a/src/test/scala/DisjunctionMatchersSpec.scala
+++ b/src/test/scala/DisjunctionMatchersSpec.scala
@@ -9,7 +9,8 @@ class DisjunctionMatchersSpec extends Specification with DisjunctionMatchers { d
     match \/-                     $rightMatches
 
   beLeftDisjunction should
-    match -\/                     $leftMatches"""
+    match -\/                     $leftMatches
+  """
 
   def rightMatches =
     (\/.right(3) must     beRightDisjunction.like{
@@ -18,9 +19,15 @@ class DisjunctionMatchersSpec extends Specification with DisjunctionMatchers { d
     (\/.right(3) must     beRightDisjunction)     and
     (\/.right(3) must     beRightDisjunction(3))  and
     (\/.left(3)  must not beRightDisjunction)     and
+    (\/.right(4) must not beRightDisjunction(3))  and
     (\/.right(3) must     be rightDisjunction)    and
     (\/.right(3) must     be rightDisjunction(3)) and
-    (\/.left(3)  must not be rightDisjunction)
+    (\/.left(3)  must not be rightDisjunction)    and
+    (\/.right(4) must not be rightDisjunction(3)) and
+    (\/.right(3) must     be_\/-)                 and
+    (\/.right(3) must     be_\/-(3))              and
+    (\/.left(3)  must not be_\/-)                 and
+    (\/.right(4) must not be_\/-(3))
 
   def leftMatches =
     (\/.left(3)  must     beLeftDisjunction.like{
@@ -29,9 +36,15 @@ class DisjunctionMatchersSpec extends Specification with DisjunctionMatchers { d
     (\/.right(3) must not beLeftDisjunction)     and
     (\/.left(3)  must     beLeftDisjunction)     and
     (\/.left(3)  must     beLeftDisjunction(3))  and
+    (\/.left(4)  must not beLeftDisjunction(3))  and
     (\/.right(3) must not be leftDisjunction)    and
     (\/.left(3)  must     be leftDisjunction)    and
-    (\/.left(3)  must     be leftDisjunction(3))
+    (\/.left(3)  must     be leftDisjunction(3)) and
+    (\/.left(4)  must not be leftDisjunction(3)) and
+    (\/.right(3) must not be_-\/)                and
+    (\/.left(3)  must     be_-\/)                and
+    (\/.left(3)  must     be_-\/(3))             and
+    (\/.left(4)  must not be_-\/(3))
 }
 
 // vim: expandtab:ts=2:sw=2


### PR DESCRIPTION
These proposed new aliases are shorter and resemble to the disjunctions defined in scalaz.
