### PR TITLE
Bump Scala version also in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: scala
 sudo: false
 scala:
   - 2.10.6
-  - 2.11.7
+  - 2.11.8
 jdk:
   - oraclejdk7


### PR DESCRIPTION
This updates the Scala version to the same version that is used in `build.sbt`.