### PR TITLE
remove Function1IntInt

### DIFF
--- a/src/main/scala/Spec.scala
+++ b/src/main/scala/Spec.scala
@@ -38,16 +38,6 @@ trait Spec extends org.specs2.mutable.Spec with ScalaCheck
     }
   }
 
-  /**
-   * Most of our scalacheck tests use (Int => Int). This generator includes non-constant
-   * functions (id, inc), to have a better chance at catching bugs.
-   */
-  implicit def Function1IntInt[A](implicit A: Arbitrary[Int]): Arbitrary[Int => Int] =
-    Arbitrary(Gen.frequency[Int => Int](
-      (1, Gen.const((x: Int) => x)),
-      (1, Gen.const((x: Int) => x + 1)),
-      (3, A.arbitrary.map(a => (_: Int) => a))
-    ))
 }
 
 // vim: expandtab:ts=2:sw=2


### PR DESCRIPTION
scalacheck generate non-constant Function Arbitrary since 1.13.0

https://github.com/rickynils/scalacheck/pull/171