### PR TITLE
Bump to specs 4.0.2, scalaz 7.2.18, scala 2.12.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: scala
 sudo: false
 scala:
-  - 2.10.6
   - 2.11.11
-  - 2.12.2
+  - 2.12.4
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This library is currently available for Scala binary versions 2.10, 2.11, and 2.
 To use the latest version, include the following dependency in your `build.sbt`:
 
 ```scala
-// for Scalaz 7.2.x and specs2 3.9.x
-libraryDependencies += "org.typelevel" %% "scalaz-specs2" % "0.5.0" % "test"
+// for Scalaz 7.2.x and specs2 4.0.x
+libraryDependencies += "org.typelevel" %% "scalaz-specs2" % "0.5.2" % "test"
 ```
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,10 +16,9 @@ scalacOptions ++= Seq(
 scalacOptions in Test ++= Seq("-Yrangepos")
 
 libraryDependencies ++= {
-  // specs2 3.7 is the last version to use scalacheck 1.12.5
-  val specs2Version = "3.9.5"
+  val specs2Version = "4.0.2"
   Seq(
-    "org.scalaz" %% "scalaz-core" % "7.2.15",
+    "org.scalaz" %% "scalaz-core" % "7.2.18",
     "org.scalacheck" %% "scalacheck" % "1.13.5",
     "org.specs2" %% "specs2-core" % specs2Version,
     "org.specs2" %% "specs2-scalacheck" % specs2Version


### PR DESCRIPTION
I bumped versions to 
specs2 4.0.2
scalaz 7.2.18
scala 2.12.4

It also means dropping support for scala 2.10 as specs 4.0.x is not released for it anymore.

It would be nice if this was released as we need it for quasar here https://github.com/quasar-analytics/quasar/pull/3338 It turned out that 3.9.1 was not enough...